### PR TITLE
Panic on unsupported HTTP method

### DIFF
--- a/flow.go
+++ b/flow.go
@@ -113,6 +113,10 @@ func (m *Mux) Handle(pattern string, handler http.Handler, methods ...string) {
 	}
 
 	for _, method := range methods {
+		if !contains(AllMethods, method) {
+			panic("unsupported HTTP method: " + method)
+		}
+
 		route := route{
 			method:   strings.ToUpper(method),
 			segments: strings.Split(pattern, "/"),


### PR DESCRIPTION
Right now it's possible for routes to be added to methods that will never be called. I happened to do this since the readme implicitly encouraged defining methods as strings, and I accidentally made a typo and saw that it wasn’t caught at runtime. This 3-line PR will identify the error and panic at route definition.

Thanks for writing this package, by the way – I'm learning how to develop web services in Go using your books and am considering using this router in a production setting since I expect my service won't be particularly CPU-bound and I enjoy the minimal-dependency life. :-)

Edit: Hmm, maybe the error message should say "invalid HTTP method" rather than "unsupported". 

Edit 2: An alternative might be to change the example code to use `http.MethodGet`, which would make it impossible for this sort of typo to compile. 