### PR TITLE
feat: Add support for Percent-Encoding RFC 3986

### DIFF
--- a/flow.go
+++ b/flow.go
@@ -165,7 +165,7 @@ func (m *Mux) Group(fn func(*Mux)) {
 
 // ServeHTTP makes the router implement the http.Handler interface.
 func (m *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	urlSegments := strings.Split(r.URL.Path, "/")
+	urlSegments := strings.Split(r.URL.EscapedPath(), "/")
 	allowedMethods := []string{}
 
 	for _, route := range *m.routes {

--- a/flow_test.go
+++ b/flow_test.go
@@ -95,6 +95,11 @@ func TestMatching(t *testing.T) {
 			"GET", "/path-params/60/beatles/lennon/bar",
 			http.StatusNotFound, map[string]string{"era": "60", "group": "beatles", "member": "lennon"}, "",
 		},
+		{
+			[]string{"GET"}, "/path-params/:era",
+			"GET", "/path-params/a%3A%2F%2Fb%2Fc",
+			http.StatusOK, map[string]string{"era": "a%3A%2F%2Fb%2Fc"}, "",
+		},
 		// regexp
 		{
 			[]string{"GET"}, "/path-params/:era|^[0-9]{2}$/:group|^[a-z].+$",


### PR DESCRIPTION
**Problem**:
The current implementation does not allow to use of encoded named parameters like:
`/path/:param` - `/path-params/a%3A%2F%2Fb%2Fc`

Which is fully legal by [RFC 3986](http://www.ietf.org/rfc/rfc3986.txt)

Solution:
Use [EscapedPath()](https://pkg.go.dev/net/url#URL.EscapedPath) instead of direct access to a `u.Path`

> Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/. A consequence is that it is impossible to tell which slashes in the Path were slashes in the raw URL and which were %2f. This distinction is rarely important, but when it is, the code should use the [URL.EscapedPath](https://pkg.go.dev/net/url#URL.EscapedPath) method, which preserves the original encoding of Path.

Details:
https://pkg.go.dev/net/url#URL